### PR TITLE
fix: URL encode source UIDs in API requests

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -141,7 +141,7 @@ export function getActions() {
 		],
 		callback: (action) => {
 			if (action.options.source !== null) {
-				cmd = `sources/${action.options.source}/lock`
+				cmd = `sources/${encodeURIComponent(action.options.source)}/lock`
 				type = 'GET'
 
 				this.sendCommand(cmd, type)
@@ -162,7 +162,7 @@ export function getActions() {
 		],
 		callback: (action) => {
 			if (action.options.source !== null) {
-				cmd = `sources/${action.options.source}/unlock`
+				cmd = `sources/${encodeURIComponent(action.options.source)}/unlock`
 				type = 'GET'
 
 				this.sendCommand(cmd, type)
@@ -184,7 +184,7 @@ export function getActions() {
 		],
 		callback: (action) => {
 			if (action.options.source !== null) {
-				cmd = `sources/${action.options.source}/manual_split`
+				cmd = `sources/${encodeURIComponent(action.options.source)}/manual_split`
 				type = 'GET'
 
 				this.sendCommand(cmd, type)
@@ -214,7 +214,7 @@ export function getActions() {
 		callback: async (action) => {
 			if (action.options.source !== null) {
 				const recordingName = await this.parseVariablesInString(action.options.recordName)
-				cmd = `sources/${action.options.source}/recording_name`
+				cmd = `sources/${encodeURIComponent(action.options.source)}/recording_name`
 				type = 'PUT'
 				params = {
 					recording_name: recordingName.length ? recordingName : 'New Recording',
@@ -246,7 +246,7 @@ export function getActions() {
 		],
 		callback: (action) => {
 			if (action.options.source !== null && action.options.destination !== null) {
-				cmd = `sources/${action.options.source}/destinations`
+				cmd = `sources/${encodeURIComponent(action.options.source)}/destinations`
 				type = 'PUT'
 				params = action.options.destination
 

--- a/index.js
+++ b/index.js
@@ -462,7 +462,7 @@ class MovieRecorderInstance extends InstanceBase {
 	async getThumbnailImage(sourceId) {
 		try {
 			const protocol = this.config.useHttps ? 'https' : 'http'
-			const url = `${protocol}://${this.config.host}:${this.config.port}/sources/${sourceId}/thumbnail${this.password}`
+			const url = `${protocol}://${this.config.host}:${this.config.port}/sources/${encodeURIComponent(sourceId)}/thumbnail${this.password}`
 
 			// Allow self-signed certificates when using HTTPS
 			const agent = this.config.useHttps ? new https.Agent({ rejectUnauthorized: false }) : undefined

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "softron-movierecorder",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Fix URL encoding for source UIDs containing special characters

Wrapped source IDs with encodeURIComponent() when interpolated into URL
paths to handle UIDs with spaces, question marks, and other special
characters.

Verison bump 2.4.2 for release